### PR TITLE
fix: parse proxy header envs correctly - fixes #15

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,15 @@ You can use http proxies by setting the following environment variables:
 - `IONOS_HTTP_PROXY` - proxy URL
 - `IONOS_HTTP_PROXY_HEADERS` - proxy headers
 
+Each line in `IONOS_HTTP_PROXY_HEADERS` represents one header, where the header name and value is separated by a colon. Newline characters within a value need to be escaped. See this example:
+```
+Connection: Keep-Alive
+User-Info: MyID
+User-Group: my long\nheader value
+```
+
+
+
 ### Depth
 
 Many of the _List_ or _Get_ operations will accept an optional _depth_ argument. Setting this to a value between 0 and 5 affects the amount of data that is returned. The details returned vary depending on the resource being queried, but it generally follows this pattern. By default, the SDK sets the _depth_ argument to the maximum value.

--- a/ionoscloud/configuration.py
+++ b/ionoscloud/configuration.py
@@ -219,7 +219,11 @@ conf = ionoscloud.Configuration(
         self.proxy = os.environ.get('IONOS_HTTP_PROXY')
         """Proxy URL
         """
-        self.proxy_headers = os.environ.get('IONOS_HTTP_PROXY_HEADERS')
+        self.proxy_headers = {}
+        proxy_headers_list = os.environ.get('IONOS_HTTP_PROXY_HEADERS','').splitlines()
+        for header in proxy_headers_list:
+            k,v = header.split(':', 1)
+            self.proxy_headers[k.strip()] = bytes(v.lstrip(), "utf-8").decode("unicode_escape")
         """Proxy headers
         """
         self.safe_chars_for_path_param = '/'


### PR DESCRIPTION
This fixes the bug reported in #15.

Is is a serious problem for us since we experiance sporadic but repeated proxy disconnects. The error message is when used via ansible:
```
"msg": "failed to create the new server: ('Unable to connect to proxy', RemoteDisconnected('Remote end closed connection without response'))"
```

The modification was tested without and with ansible

Closes #15